### PR TITLE
Update README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ We plan on using the [Huggingface Transformer](https://github.com/huggingface/tr
 The [data](https://www.kaggle.com/competitions/fake-news/data) is made available through the competition. This dataset contains the following features for each news article: A unique ID, the title, the author, the textual content, and finally a binary label of 0 or 1 corresponding to “reliable” and unreliable respectively. The model will be trained using DTU HPC.
 
 ### Models
-We expect to use a transformer model made for Natural Language Processing - specifically a pre-trained BERT. The model used is the base version with 12 layers and 12 self-attention heads. The hidden size is 784.
+We expect to use a transformer model made for Natural Language Processing - specifically a pre-trained BERT. The model used is the base version with 12 layers and 12 self-attention heads. The hidden size is 768.
 
 ### Usage
-To use this project, you will need to install the required packages listed in requirements.txt. You can then run the scripts in the src directory to process the data, build features, train models, and make predictions. The Makefile includes commands for running these scripts, such as make data, make train, and make predict.
+To use this project, you will need to install the required packages listed in requirements.txt. You can then run the scripts in the src directory to process the data, build features, train models, and make predictions. The Makefile includes commands for running these scripts, such as make data, make train, and make evaluate.
 
 ### License
 This project is licensed under the terms of the MIT License.


### PR DESCRIPTION
## Summary
- correct BERT hidden size description
- update example command to `make evaluate`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684fb1be000c8323ad76f857f26d3eeb